### PR TITLE
Move "filp/whoops" from "require-dev" to "require"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,6 @@
     "target-dir": "dpro/WhoopsBundle",
     "require": {
         "symfony/symfony": ">=2.1",
-        "filp/whoops":  "dev-master"
+        "filp/whoops":  "*"
     },
 }

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,7 @@
     },
     "target-dir": "dpro/WhoopsBundle",
     "require": {
-        "symfony/symfony": ">=2.1"
-    },
-    "require-dev": {
+        "symfony/symfony": ">=2.1",
         "filp/whoops":  "dev-master"
-    }
+    },
 }


### PR DESCRIPTION
"require-dev" is loaded only from the root composer.json.

Also use stable version of "filp/whoops".
